### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -19,7 +19,7 @@ from .visitors.vision import (
 )
 from .visitors.security import TorchUnsafeLoadVisitor
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 DEPRECATED_CONFIG_PATH = Path(__file__).absolute().parent / "deprecated_symbols.yaml"
 


### PR DESCRIPTION
Preparing 0.3.0 release.

- Added rule TOR003 about explicitly passing `use_reentrant` explicitly to `torch.utils.checkpoint`
- Added `torch.nn.utils.weight_norm` to the list of deprecated functions flagged by TOR101
- Updated README with TOR0 rules description
