### PR TITLE
Use `dup2` to redirect stderr to null on MacOS

### DIFF
--- a/torchfix/__main__.py
+++ b/torchfix/__main__.py
@@ -12,7 +12,7 @@ from .common import CYAN, ENDC
 
 # Should get rid of this code eventually.
 @contextlib.contextmanager
-def StderrSilencer(redirect: bool = True) -> None:
+def StderrSilencer(redirect: bool = True):
     if not redirect:
         yield
     elif sys.platform != "darwin":

--- a/torchfix/__main__.py
+++ b/torchfix/__main__.py
@@ -1,12 +1,44 @@
 import argparse
 import libcst.codemod as codemod
 
+import ctypes
 import contextlib
 import sys
 import io
+from ctypes import CDLL
 
 from .torchfix import TorchCodemod, TorchCodemodConfig, __version__ as TorchFixVersion
 from .common import CYAN, ENDC
+
+
+# Should get rid of this code eventually.
+class StderrSilencer:
+    def __init__(self, redirect:bool = True) -> None:
+        self.redirect = redirect
+        self.context = contextlib.redirect_stderr(io.StringIO())
+        if sys.platform == "darwin":
+            self.libc = CDLL("libc.dylib")
+            self.devnull = open("/dev/null", "w")
+
+    def __enter__(self) -> None:
+        if not self.redirect: return
+        if sys.platform == "darwin":
+            # redirect_stderr does not work for some reason
+            # Workaround it by using good old dup2 to redirect
+            # stderr to /dev/null
+            self.orig_stderr = self.libc.dup(2)
+            self.libc.dup2(self.devnull.fileno(), 2)
+        else:
+            self.context.__enter__()
+
+    def __exit__(self) -> None:
+        if not self.redirect:
+            return
+        if sys.platform == "darwin":
+            self.libc.dup2(self.orig_stderr, 2)
+            self.libc.close(self.orig_stderr)
+        else:
+            self.context.__exit__()
 
 
 def main() -> None:
@@ -74,12 +106,7 @@ def main() -> None:
     command_instance = TorchCodemod(codemod.CodemodContext(), config)
     DIFF_CONTEXT = 5
     try:
-        if not args.show_stderr:
-            context = contextlib.redirect_stderr(io.StringIO())
-        else:
-            # Should get rid of this code eventually.
-            context = contextlib.nullcontext()  # type: ignore
-        with context:
+        with StderrSilencer(not args.show_stderr):
             result = codemod.parallel_exec_transform_with_prettyprint(
                 command_instance,
                 torch_files,


### PR DESCRIPTION
Not sure why `contextlib.redirect_stderr(io.StringIO())` does not work,
but `dup2(open("/dev/null", O_WRONLY), 2)` do work on MacOS (and on Linux as well)

Create `StderrSilencer` context manager that will choose the right way to redirect stderr, depending on the platform
