### PR TITLE
Require at least Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "TorchFix"
+requires-python = ">=3.9"
 description = "TorchFix - a linter for PyTorch-using code with autofix support"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
LibCST requires Python >= 3.9.
(also we want to use `@functools.cache`).