### PR TITLE
Add TorchScopedLibraryVisitor

### DIFF
--- a/tests/fixtures/internal/checker/scoped_library.py
+++ b/tests/fixtures/internal/checker/scoped_library.py
@@ -1,0 +1,3 @@
+import torch
+from torch.library import Library, impl, fallthrough_kernel
+my_lib1 = Library("aten", "IMPL")

--- a/tests/fixtures/internal/checker/scoped_library.txt
+++ b/tests/fixtures/internal/checker/scoped_library.txt
@@ -1,0 +1,1 @@
+3:11 TOR901 Use `torch.library._scoped_library` instead of `torch.library.Library` in PyTorch tests files. See https://github.com/pytorch/pytorch/pull/118318 for details.

--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -11,6 +11,8 @@ from .visitors.deprecated_symbols import (
     _UpdateFunctorchImports,
 )
 
+from .visitors.internal import TorchScopedLibraryVisitor
+
 from .visitors.performance import TorchSynchronizedDataLoaderVisitor
 from .visitors.misc import (TorchRequireGradVisitor, TorchReentrantCheckpointVisitor)
 
@@ -24,11 +26,12 @@ __version__ = "0.3.0"
 
 DEPRECATED_CONFIG_PATH = Path(__file__).absolute().parent / "deprecated_symbols.yaml"
 
-DISABLED_BY_DEFAULT = ["TOR3", "TOR4"]
+DISABLED_BY_DEFAULT = ["TOR3", "TOR4", "TOR9"]
 
 ALL_VISITOR_CLS = [
     TorchDeprecatedSymbolsVisitor,
     TorchRequireGradVisitor,
+    TorchScopedLibraryVisitor,
     TorchSynchronizedDataLoaderVisitor,
     TorchVisionDeprecatedPretrainedVisitor,
     TorchVisionDeprecatedToTensorVisitor,

--- a/torchfix/visitors/internal/__init__.py
+++ b/torchfix/visitors/internal/__init__.py
@@ -1,0 +1,33 @@
+import libcst as cst
+from ...common import TorchVisitor, LintViolation
+
+
+class TorchScopedLibraryVisitor(TorchVisitor):
+    """
+    Suggest `torch.library._scoped_library` for PyTorch tests.
+    """
+
+    ERROR_CODE = "TOR901"
+    MESSAGE = (
+        "Use `torch.library._scoped_library` instead of `torch.library.Library` "
+        "in PyTorch tests files. See https://github.com/pytorch/pytorch/pull/118318 "
+        "for details."
+    )
+
+    def visit_Call(self, node):
+        qualified_name = self.get_qualified_name_for_call(node)
+        if qualified_name == "torch.library.Library":
+            position_metadata = self.get_metadata(
+                cst.metadata.WhitespaceInclusivePositionProvider, node
+            )
+
+            self.violations.append(
+                LintViolation(
+                    error_code=self.ERROR_CODE,
+                    message=self.MESSAGE,
+                    line=position_metadata.start.line,
+                    column=position_metadata.start.column,
+                    node=node,
+                    replacement=None,
+                )
+            )


### PR DESCRIPTION
This PR adds a new category of rules, 'internal': rules that are used for PyTorch code itself, not for PyTorch users.
These rules starts with TOR9 and are not enabled by default.

The TorchScopedLibraryVisitor rule is based on https://github.com/pytorch/pytorch/pull/118318 and a lint-only for now.
I'll try to add a codemod for it in the next PR. Codemod would be somewhat complicated, but probably worth it as the `pytorch/test/test_python_dispatch.py` file is thousands of lines of code.