### PR TITLE
Fix bug with function name replacement

### DIFF
--- a/tests/fixtures/deprecated_symbols/codemod/ger-outer.py
+++ b/tests/fixtures/deprecated_symbols/codemod/ger-outer.py
@@ -1,6 +1,9 @@
 import torch
+from torch import ger
 deprecated = torch.norm()
 sinusoid_inp = torch.ger(pos_seq, inv_freq)
 other = something.ger(pos_seq, inv_freq)
 deprecated = torch.norm()
 one_more = torch.ger(pos_seq, inv_freq)
+
+just_name = ger(pos_seq, inv_freq)

--- a/tests/fixtures/deprecated_symbols/codemod/ger-outer.py.out
+++ b/tests/fixtures/deprecated_symbols/codemod/ger-outer.py.out
@@ -1,6 +1,9 @@
 import torch
+from torch import outer, ger
 deprecated = torch.norm()
 sinusoid_inp = torch.outer(pos_seq, inv_freq)
 other = something.ger(pos_seq, inv_freq)
 deprecated = torch.norm()
 one_more = torch.outer(pos_seq, inv_freq)
+
+just_name = outer(pos_seq, inv_freq)

--- a/torchfix/visitors/deprecated_symbols/__init__.py
+++ b/torchfix/visitors/deprecated_symbols/__init__.py
@@ -49,10 +49,12 @@ class TorchDeprecatedSymbolsVisitor(TorchVisitor):
                 qualified_name, {}
             ).get("replacement", "")
             if function_name_replacement:
-                replacement = call_with_name_changes(
+                replacement_and_imports = call_with_name_changes(
                     node, qualified_name, function_name_replacement
                 )
-
+                if replacement_and_imports is not None:
+                    replacement, imports = replacement_and_imports
+                    self.needed_imports.update(imports)
         return replacement
 
     def visit_Call(self, node):


### PR DESCRIPTION
Before this PR, TorchFix in standalone mode crashes on 
```python
from torch import ger
just_name = ger(pos_seq, inv_freq)
```

With this PR it works fine, replacing the code with 
```python
from torch import outer, ger
just_name = outer(pos_seq, inv_freq)
```

Note that the replacement code still imports no longer needed `ger`, but that can be caught and fixed by existing linters like ruff.
Nevertheless, I'll create an issue to clean this up later in TorchFix.