### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -22,7 +22,7 @@ from .visitors.vision import (
 )
 from .visitors.security import TorchUnsafeLoadVisitor
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 DEPRECATED_CONFIG_PATH = Path(__file__).absolute().parent / "deprecated_symbols.yaml"
 


### PR DESCRIPTION
Preparing 0.4.0 release.

- Improvements for the standalone `torchfix` command:
     - Added  `--version` flag
     - `--select` flag now accepts specific rules, not just `ALL`
     - Fixed excessive debug output on MacOS
- Added PyTorch-internal rule TOR901
- TorchFix explicitly requires at least Python 3.9 now
- Small clean-ups and bugfixes