### PR TITLE
Add ReplaceImportsTransformer

### DIFF
--- a/tests/test_torchfix.py
+++ b/tests/test_torchfix.py
@@ -27,6 +27,8 @@ def _codemod_results(source_path):
     config = TorchCodemodConfig(select=list(GET_ALL_ERROR_CODES()))
     context = TorchCodemod(codemod.CodemodContext(filename=source_path), config)
     new_module = codemod.transform_module(context, code)
+    if isinstance(new_module, codemod.TransformFailure):
+        raise new_module.error
     return new_module.code
 
 


### PR DESCRIPTION
Resolve a TODO of replacing ad-hoc `_UpdateFunctorchImports` with more generic `ReplaceImportsTransformer`.
This fixes https://github.com/pytorch-labs/torchfix/issues/24 and unblocks work on the visitors that need updating imports.