### PR TITLE
Raise original exception when test hits codemod.TransformFailure

### DIFF
--- a/tests/test_torchfix.py
+++ b/tests/test_torchfix.py
@@ -27,6 +27,8 @@ def _codemod_results(source_path):
     config = TorchCodemodConfig(select=list(GET_ALL_ERROR_CODES()))
     context = TorchCodemod(codemod.CodemodContext(filename=source_path), config)
     new_module = codemod.transform_module(context, code)
+    if isinstance(new_module, codemod.TransformFailure):
+        raise new_module.error    
     return new_module.code
 
 

--- a/tests/test_torchfix.py
+++ b/tests/test_torchfix.py
@@ -28,7 +28,7 @@ def _codemod_results(source_path):
     context = TorchCodemod(codemod.CodemodContext(filename=source_path), config)
     new_module = codemod.transform_module(context, code)
     if isinstance(new_module, codemod.TransformFailure):
-        raise new_module.error    
+        raise new_module.error
     return new_module.code
 
 


### PR DESCRIPTION
Otherwise it's very hard to tell why the test failed.