### PR TITLE
Fix for TorchVisionModelsImportVisitor

### DIFF
--- a/tests/fixtures/vision/checker/models_import.txt
+++ b/tests/fixtures/vision/checker/models_import.txt
@@ -1,1 +1,2 @@
 1:1 TOR203 Consider replacing 'import torchvision.models as models' with 'from torchvision import models'.
+6:1 TOR203 Consider replacing 'import torchvision.models as models' with 'from torchvision import models'.

--- a/tests/fixtures/vision/codemod/models_import.py
+++ b/tests/fixtures/vision/codemod/models_import.py
@@ -1,6 +1,5 @@
 import torchvision.models as models
 import torchvision.models as cnn
-from torchvision.models import resnet50, resnet101
-import torchvision.models
-from torchvision.models import *
+
+# don't touch is more than one name imported
 import torchvision.models as models, torch

--- a/tests/fixtures/vision/codemod/models_import.py
+++ b/tests/fixtures/vision/codemod/models_import.py
@@ -1,5 +1,5 @@
 import torchvision.models as models
 import torchvision.models as cnn
 
-# don't touch is more than one name imported
+# don't touch if more than one name imported
 import torchvision.models as models, torch

--- a/tests/fixtures/vision/codemod/models_import.py.out
+++ b/tests/fixtures/vision/codemod/models_import.py.out
@@ -1,0 +1,5 @@
+from torchvision import models
+import torchvision.models as cnn
+
+# don't touch is more than one name imported
+import torchvision.models as models, torch

--- a/tests/fixtures/vision/codemod/models_import.py.out
+++ b/tests/fixtures/vision/codemod/models_import.py.out
@@ -1,5 +1,5 @@
 from torchvision import models
 import torchvision.models as cnn
 
-# don't touch is more than one name imported
+# don't touch if more than one name imported
 import torchvision.models as models, torch


### PR DESCRIPTION
Add codemod tests, don't replace when an import statement has more than 1 name (but still print the message).