### PR TITLE
Update to checkout action v4

### DIFF
--- a/.github/workflows/test-torchfix.yml
+++ b/.github/workflows/test-torchfix.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install requirements
         run: |
           pip3 install -r requirements-dev.txt


### PR DESCRIPTION
To get rid of the warning

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/