### PR TITLE
Refactored each import item from node using libcst.matchers.matches

### DIFF
--- a/torchfix/visitors/vision/models_import.py
+++ b/torchfix/visitors/vision/models_import.py
@@ -1,4 +1,5 @@
 import libcst as cst
+import libcst.matchers as m
 
 from ...common import TorchVisitor
 
@@ -13,7 +14,7 @@ class TorchVisionModelsImportVisitor(TorchVisitor):
     def visit_Import(self, node: cst.Import) -> None:
         replacement = None
         for imported_item in node.names:
-            # Refactor each import item from node using libcst.matchers.matches
+            #  Check matches on each imported items from node
             if m.matches(imported_item, m.ImportAlias(
                 name=m.Attribute(value=m.Name("torchvision"),
                                     attr=m.Name("models")),

--- a/torchfix/visitors/vision/models_import.py
+++ b/torchfix/visitors/vision/models_import.py
@@ -14,7 +14,6 @@ class TorchVisionModelsImportVisitor(TorchVisitor):
     def visit_Import(self, node: cst.Import) -> None:
         replacement = None
         for imported_item in node.names:
-            #  Check matches on each imported items from node
             if m.matches(imported_item, m.ImportAlias(
                 name=m.Attribute(value=m.Name("torchvision"),
                                     attr=m.Name("models")),

--- a/torchfix/visitors/vision/models_import.py
+++ b/torchfix/visitors/vision/models_import.py
@@ -16,7 +16,7 @@ class TorchVisionModelsImportVisitor(TorchVisitor):
         for imported_item in node.names:
             if m.matches(imported_item, m.ImportAlias(
                 name=m.Attribute(value=m.Name("torchvision"),
-                                attr=m.Name("models")),
+                attr=m.Name("models")),
                 asname=m.AsName(name=m.Name("models"))
             )):
                 # Replace only if the import statement has no other names

--- a/torchfix/visitors/vision/models_import.py
+++ b/torchfix/visitors/vision/models_import.py
@@ -13,27 +13,22 @@ class TorchVisionModelsImportVisitor(TorchVisitor):
     def visit_Import(self, node: cst.Import) -> None:
         replacement = None
         for imported_item in node.names:
-            if isinstance(imported_item.name, cst.Attribute):
-                # TODO refactor using libcst.matchers.matches
-                if (
-                    isinstance(imported_item.name.value, cst.Name)
-                    and imported_item.name.value.value == "torchvision"
-                    and isinstance(imported_item.name.attr, cst.Name)
-                    and imported_item.name.attr.value == "models"
-                    and imported_item.asname is not None
-                    and isinstance(imported_item.asname.name, cst.Name)
-                    and imported_item.asname.name.value == "models"
-                ):
-                    # Replace only if the import statement has no other names
-                    if len(node.names) == 1:
-                        replacement = cst.ImportFrom(
-                            module=cst.Name("torchvision"),
-                            names=[cst.ImportAlias(name=cst.Name("models"))],
-                        )
-                    self.add_violation(
-                        node,
-                        error_code=self.ERROR_CODE,
-                        message=self.MESSAGE,
-                        replacement=replacement,
+            # Refactor each import item from node using libcst.matchers.matches
+            if m.matches(imported_item, m.ImportAlias(
+                name=m.Attribute(value=m.Name("torchvision"),
+                                    attr=m.Name("models")),
+                asname=m.AsName(name=m.Name("models"))
+            )):
+                # Replace only if the import statement has no other names
+                if len(node.names) == 1:
+                    replacement = cst.ImportFrom(
+                        module=cst.Name("torchvision"),
+                        names=[cst.ImportAlias(name=cst.Name("models"))],
                     )
-                break
+                self.add_violation(
+                    node,
+                    error_code=self.ERROR_CODE,
+                    message=self.MESSAGE,
+                    replacement=replacement,
+                )
+            break

--- a/torchfix/visitors/vision/models_import.py
+++ b/torchfix/visitors/vision/models_import.py
@@ -16,7 +16,7 @@ class TorchVisionModelsImportVisitor(TorchVisitor):
         for imported_item in node.names:
             if m.matches(imported_item, m.ImportAlias(
                 name=m.Attribute(value=m.Name("torchvision"),
-                attr=m.Name("models")),
+                                 attr=m.Name("models")),
                 asname=m.AsName(name=m.Name("models"))
             )):
                 # Replace only if the import statement has no other names

--- a/torchfix/visitors/vision/models_import.py
+++ b/torchfix/visitors/vision/models_import.py
@@ -16,7 +16,7 @@ class TorchVisionModelsImportVisitor(TorchVisitor):
         for imported_item in node.names:
             if m.matches(imported_item, m.ImportAlias(
                 name=m.Attribute(value=m.Name("torchvision"),
-                                    attr=m.Name("models")),
+                                attr=m.Name("models")),
                 asname=m.AsName(name=m.Name("models"))
             )):
                 # Replace only if the import statement has no other names


### PR DESCRIPTION
Modified code still performs the same checks for outdated import statement "import torchvision.models as models" using libcst.matchers.matches as suggested by ticket [T182198161](https://www.internalfb.com/intern/tasks/?t=182198161). 
IsInstance checks are removed because m.ImportAlias() already ensured the right instance is used.