### PR TITLE
Fix deprecated symbol loading in zipped deployments

### DIFF
--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -26,7 +26,7 @@ from .visitors.security import TorchUnsafeLoadVisitor
 
 __version__ = "0.4.0"
 
-DEPRECATED_CONFIG_PATH = Path(__file__).absolute().parent / "deprecated_symbols.yaml"
+DEPRECATED_CONFIG_PATH = "deprecated_symbols.yaml"
 
 DISABLED_BY_DEFAULT = ["TOR3", "TOR4", "TOR9"]
 

--- a/torchfix/visitors/deprecated_symbols/__init__.py
+++ b/torchfix/visitors/deprecated_symbols/__init__.py
@@ -1,4 +1,5 @@
 import libcst as cst
+import pkgutil
 import yaml
 from typing import Optional
 from collections.abc import Sequence
@@ -21,9 +22,9 @@ class TorchDeprecatedSymbolsVisitor(TorchVisitor):
         def read_deprecated_config(path=None):
             deprecated_config = {}
             if path is not None:
-                with open(path) as f:
-                    for item in yaml.load(f, yaml.SafeLoader):
-                        deprecated_config[item["name"]] = item
+                data = pkgutil.get_data("torchfix", path)
+                for item in yaml.load(data, yaml.SafeLoader):
+                    deprecated_config[item["name"]] = item
             return deprecated_config
 
         super().__init__()


### PR DESCRIPTION
torchfix currentyl uses standard filesystem methods to find and load the
deprecated symbols data from disk. When running flake8 as zipped
deployments, this fails because the data is not accessible as a standard
filesystem path.

This replaces the filesystem usage with stdlib `pkgutil.get_data()` [1]
that is capable of resolving the data file within the zip deployment,
and loading that data using the correct internal mechanisms.

1: https://docs.python.org/3/library/pkgutil.html#pkgutil.get_data
