### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -24,7 +24,7 @@ from .visitors.vision import (
 )
 from .visitors.security import TorchUnsafeLoadVisitor
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 DEPRECATED_CONFIG_PATH = "deprecated_symbols.yaml"
 


### PR DESCRIPTION
Preparing 0.5.0 release.

- Added rule TOR203 to replace 'import torchvision.models as models' with 'from torchvision import models'
- Added rules TOR104 and TOR105 for calling and importing non-public PyTorch functions that have known public aliases
- Added rules TOR004 and TOR103 for importing removed and deprecated functions (in addition to the existing rules for calling those functions)
- Fixed loading for deprecated symbols config in zipped deployments
- Done several smaller bug fixes and refactorings