### PR TITLE
Add rule for deprecated _register_pytree_node

### DIFF
--- a/tests/fixtures/deprecated_symbols/checker/deprecated_register_pytree_node.py
+++ b/tests/fixtures/deprecated_symbols/checker/deprecated_register_pytree_node.py
@@ -1,0 +1,9 @@
+from torch.utils._pytree import _register_pytree_node
+
+_register_pytree_node()
+
+from torch.utils import _pytree as xx
+xx._register_pytree_node()
+
+import torch.utils._pytree._register_pytree_node as yy
+yy()

--- a/tests/fixtures/deprecated_symbols/checker/deprecated_register_pytree_node.py
+++ b/tests/fixtures/deprecated_symbols/checker/deprecated_register_pytree_node.py
@@ -5,5 +5,5 @@ _register_pytree_node()
 from torch.utils import _pytree as xx
 xx._register_pytree_node()
 
-import torch.utils._pytree._register_pytree_node as yy
-yy()
+import torch
+torch.utils._pytree._register_pytree_node()

--- a/tests/fixtures/deprecated_symbols/checker/deprecated_register_pytree_node.txt
+++ b/tests/fixtures/deprecated_symbols/checker/deprecated_register_pytree_node.txt
@@ -1,0 +1,4 @@
+1:1 TOR103 Import of deprecated function torch.utils._pytree._register_pytree_node
+3:1 TOR101 Use of deprecated function torch.utils._pytree._register_pytree_node
+6:1 TOR101 Use of deprecated function torch.utils._pytree._register_pytree_node
+9:1 TOR101 Use of deprecated function torch.utils._pytree._register_pytree_node

--- a/tests/fixtures/deprecated_symbols/codemod/register_pytree_node.py
+++ b/tests/fixtures/deprecated_symbols/codemod/register_pytree_node.py
@@ -1,0 +1,9 @@
+from torch.utils._pytree import _register_pytree_node
+
+_register_pytree_node()
+
+from torch.utils import _pytree as xx
+xx._register_pytree_node()
+
+import torch
+torch.utils._pytree._register_pytree_node()

--- a/tests/fixtures/deprecated_symbols/codemod/register_pytree_node.py.out
+++ b/tests/fixtures/deprecated_symbols/codemod/register_pytree_node.py.out
@@ -1,0 +1,9 @@
+from torch.utils._pytree import register_pytree_node, _register_pytree_node
+
+register_pytree_node()
+
+from torch.utils import _pytree as xx
+xx.register_pytree_node()
+
+import torch
+torch.utils._pytree.register_pytree_node()

--- a/torchfix/deprecated_symbols.yaml
+++ b/torchfix/deprecated_symbols.yaml
@@ -65,6 +65,11 @@
   remove_pr:
   reference: https://github.com/pytorch-labs/torchfix#torchnnutilsweight_norm
 
+- name: torch.utils._pytree._register_pytree_node
+  deprecate_pr: https://github.com/pytorch/pytorch/pull/112111
+  remove_pr:
+  replacement: torch.utils._pytree.register_pytree_node
+
 - name: torch.backends.cuda.sdp_kernel
   deprecate_pr: https://github.com/pytorch/pytorch/pull/114689
   remove_pr:


### PR DESCRIPTION
Fixes https://github.com/pytorch-labs/torchfix/issues/41

Testing:
- Added unit tests
- Ran torchfix against a directory that used this deprecated function and verified that the func was only caught after the change