### PR TITLE
[refactoring] Extract helper method `has_specific_arg`

### DIFF
--- a/torchfix/common.py
+++ b/torchfix/common.py
@@ -81,7 +81,7 @@ class TorchVisitor(cst.BatchableCSTVisitor, ABC):
             node: cst.Call, arg_name: str, position: Optional[int] = None
     ) -> bool:
         """
-        Check if a named argument is present in a call (not positional).
+        Check if the specific argument is present in a call.
         """
         return TorchVisitor.get_specific_arg(
             node, arg_name,

--- a/torchfix/common.py
+++ b/torchfix/common.py
@@ -62,7 +62,10 @@ class TorchVisitor(cst.BatchableCSTVisitor, ABC):
     def get_specific_arg(
         node: cst.Call, arg_name: str, arg_pos: int
     ) -> Optional[cst.Arg]:
-        # `arg_pos` is zero-based.
+        """
+        :param arg_pos: `arg_pos` is zero-based. -1 means it's a keyword argument.
+        :note: consider using `has_specific_arg` if you only need to check for presence.
+        """
         curr_pos = 0
         for arg in node.args:
             if arg.keyword is None:
@@ -72,6 +75,18 @@ class TorchVisitor(cst.BatchableCSTVisitor, ABC):
             elif arg.keyword.value == arg_name:
                 return arg
         return None
+
+    @staticmethod
+    def has_specific_arg(
+            node: cst.Call, arg_name: str, position: Optional[int] = None
+    ) -> bool:
+        """
+        Check if a named argument is present in a call (not positional).
+        """
+        return TorchVisitor.get_specific_arg(
+            node, arg_name,
+            position if position is not None else -1
+        ) is not None
 
     def add_violation(
         self,

--- a/torchfix/visitors/security/__init__.py
+++ b/torchfix/visitors/security/__init__.py
@@ -33,8 +33,7 @@ class TorchUnsafeLoadVisitor(TorchVisitor):
             # even without `pickle_module`,
             # so the changes need to be verified/tested.
             replacement = None
-            pickle_module_arg = self.get_specific_arg(node, "pickle_module", 2)
-            if pickle_module_arg is None:
+            if not self.has_specific_arg(node, "pickle_module", 2):
                 weights_only_arg = cst.ensure_type(
                     cst.parse_expression("f(weights_only=True)"), cst.Call
                 ).args[0]

--- a/torchfix/visitors/security/__init__.py
+++ b/torchfix/visitors/security/__init__.py
@@ -22,30 +22,28 @@ class TorchUnsafeLoadVisitor(TorchVisitor):
     ]
 
     def visit_Call(self, node):
-        qualified_name = self.get_qualified_name_for_call(node)
-        if qualified_name == "torch.load":
-            weights_only_arg = self.get_specific_arg(node, "weights_only", -1)
-            if weights_only_arg is None:
-                # Add `weights_only=True` if there is no `pickle_module`.
-                # (do not add `weights_only=False` with `pickle_module`, as it
-                # needs to be an explicit choice).
-                #
-                # This codemod is somewhat unsafe correctness-wise
-                # because full pickling functionality may still be needed
-                # even without `pickle_module`,
-                # so the changes need to be verified/tested.
-                replacement = None
-                pickle_module_arg = self.get_specific_arg(node, "pickle_module", 2)
-                if pickle_module_arg is None:
-                    weights_only_arg = cst.ensure_type(
-                        cst.parse_expression("f(weights_only=True)"), cst.Call
-                    ).args[0]
-                    replacement = node.with_changes(
-                        args=node.args + (weights_only_arg,)
-                    )
-                self.add_violation(
-                    node,
-                    error_code=self.ERRORS[0].error_code,
-                    message=self.ERRORS[0].message(),
-                    replacement=replacement,
+        if self.get_qualified_name_for_call(node) == "torch.load" and \
+                not self.has_specific_arg(node, "weights_only"):
+            # Add `weights_only=True` if there is no `pickle_module`.
+            # (do not add `weights_only=False` with `pickle_module`, as it
+            # needs to be an explicit choice).
+            #
+            # This codemod is somewhat unsafe correctness-wise
+            # because full pickling functionality may still be needed
+            # even without `pickle_module`,
+            # so the changes need to be verified/tested.
+            replacement = None
+            pickle_module_arg = self.get_specific_arg(node, "pickle_module", 2)
+            if pickle_module_arg is None:
+                weights_only_arg = cst.ensure_type(
+                    cst.parse_expression("f(weights_only=True)"), cst.Call
+                ).args[0]
+                replacement = node.with_changes(
+                    args=node.args + (weights_only_arg,)
                 )
+            self.add_violation(
+                node,
+                error_code=self.ERRORS[0].error_code,
+                message=self.ERRORS[0].message(),
+                replacement=replacement,
+            )


### PR DESCRIPTION
fix #8, 
Extracted helper method `has_specific_arg` that checks for the call argument presence, and simplified all relevant call sites:

```
        qualified_name = self.get_qualified_name_for_call(node)
        if qualified_name == "torch.load":
            weights_only_arg = self.get_specific_arg(node, "weights_only", -1)
            if weights_only_arg is None:
```
becomes:
```
       if self.get_qualified_name_for_call(node) == "torch.load" and \
                not self.has_specific_arg(node, "weights_only"):
```

### Testing

```
pytest tests
```