### PR TITLE
Refactor how import and call updates are handled

### DIFF
--- a/tests/fixtures/deprecated_symbols/codemod/ger-outer.py.out
+++ b/tests/fixtures/deprecated_symbols/codemod/ger-outer.py.out
@@ -1,5 +1,5 @@
 import torch
-from torch import outer, ger
+from torch import outer
 deprecated = torch.norm()
 sinusoid_inp = torch.outer(pos_seq, inv_freq)
 other = something.ger(pos_seq, inv_freq)

--- a/tests/fixtures/deprecated_symbols/codemod/register_pytree_node.py.out
+++ b/tests/fixtures/deprecated_symbols/codemod/register_pytree_node.py.out
@@ -1,4 +1,4 @@
-from torch.utils._pytree import register_pytree_node, _register_pytree_node
+from torch.utils._pytree import register_pytree_node
 
 register_pytree_node()
 

--- a/torchfix/common.py
+++ b/torchfix/common.py
@@ -142,6 +142,7 @@ def call_with_name_changes(
     """
     needed_imports: Set[ImportItem] = set()
     call_name = cst.helpers.get_full_name_for_node(node)
+    assert call_name is not None
     replacement = None
 
     alias_prefix = ""

--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -6,11 +6,7 @@ import libcst as cst
 import libcst.codemod as codemod
 
 from .common import deep_multi_replace
-from .visitors.deprecated_symbols import (
-    TorchDeprecatedSymbolsVisitor,
-    _UpdateFunctorchImports,
-)
-
+from .visitors.deprecated_symbols import TorchDeprecatedSymbolsVisitor
 from .visitors.internal import TorchScopedLibraryVisitor
 
 from .visitors.performance import TorchSynchronizedDataLoaderVisitor
@@ -223,10 +219,7 @@ class TorchCodemod(codemod.Codemod):
         )
         new_module = new_module.visit(add_imports_visitor)
 
-        update_functorch_imports_visitor = _UpdateFunctorchImports()
-        new_module = new_module.visit(update_functorch_imports_visitor)
-
-        if fixes_count == 0 and not update_functorch_imports_visitor.changed:
+        if fixes_count == 0:
             raise codemod.SkipFile("No changes")
 
         return new_module

--- a/torchfix/visitors/nonpublic/__init__.py
+++ b/torchfix/visitors/nonpublic/__init__.py
@@ -73,7 +73,7 @@ class TorchNonPublicAliasVisitor(TorchVisitor):
         if node.module is None:
             return
 
-        private_names, replacement = check_old_names_in_import_from(node, self.ALIASES)
+        private_names, replacement = check_old_names_in_import_from(node, self.ALIASES)  # type: ignore[arg-type] # noqa: E501
         for qualified_name in private_names:
             public_name = self.ALIASES[qualified_name]
             error_code = self.ERRORS[1].error_code

--- a/torchfix/visitors/nonpublic/__init__.py
+++ b/torchfix/visitors/nonpublic/__init__.py
@@ -1,10 +1,13 @@
-from os.path import commonprefix
-from typing import Sequence, List
+from typing import List
 
 import libcst as cst
-from libcst.codemod.visitors import ImportItem
 
-from ...common import TorchError, TorchVisitor, new_call_with_name_changes, check_old_names_in_import_from
+from ...common import (
+    TorchError,
+    TorchVisitor,
+    call_with_name_changes,
+    check_old_names_in_import_from,
+)
 
 
 class TorchNonPublicAliasVisitor(TorchVisitor):
@@ -19,13 +22,15 @@ class TorchNonPublicAliasVisitor(TorchVisitor):
 
     ERRORS: List[TorchError] = [
         TorchError(
-            "TOR104", (
+            "TOR104",
+            (
                 "Use of non-public function `{private_name}`, "
                 "please use `{public_name}` instead"
             ),
         ),
         TorchError(
-            "TOR105", (
+            "TOR105",
+            (
                 "Import of non-public function `{private_name}`, "
                 "please use `{public_name}` instead"
             ),
@@ -51,7 +56,7 @@ class TorchNonPublicAliasVisitor(TorchVisitor):
                 private_name=qualified_name, public_name=public_name
             )
 
-            replacement_and_imports = new_call_with_name_changes(
+            replacement_and_imports = call_with_name_changes(
                 node, qualified_name, public_name
             )
             if replacement_and_imports is not None:

--- a/torchfix/visitors/nonpublic/__init__.py
+++ b/torchfix/visitors/nonpublic/__init__.py
@@ -4,7 +4,7 @@ from typing import Sequence, List
 import libcst as cst
 from libcst.codemod.visitors import ImportItem
 
-from ...common import TorchError, TorchVisitor
+from ...common import TorchError, TorchVisitor, new_call_with_name_changes, check_old_names_in_import_from
 
 
 class TorchNonPublicAliasVisitor(TorchVisitor):
@@ -19,16 +19,14 @@ class TorchNonPublicAliasVisitor(TorchVisitor):
 
     ERRORS: List[TorchError] = [
         TorchError(
-            "TOR104",
-            (
-                "Use of non-public function `{qualified_name}`, "
+            "TOR104", (
+                "Use of non-public function `{private_name}`, "
                 "please use `{public_name}` instead"
             ),
         ),
         TorchError(
-            "TOR105",
-            (
-                "Import of non-public function `{qualified_name}`, "
+            "TOR105", (
+                "Import of non-public function `{private_name}`, "
                 "please use `{public_name}` instead"
             ),
         ),
@@ -50,30 +48,17 @@ class TorchNonPublicAliasVisitor(TorchVisitor):
             public_name = self.ALIASES[qualified_name]
             error_code = self.ERRORS[0].error_code
             message = self.ERRORS[0].message(
-                qualified_name=qualified_name, public_name=public_name
+                private_name=qualified_name, public_name=public_name
             )
 
-            call_name = cst.helpers.get_full_name_for_node(node)
-            replacement = None
-            if not public_name.endswith(call_name):
-                # We need to change the call name as it's not in the public name.
-                # Get the new call name on the same hierarchical level.
-                new_call_name = public_name.removeprefix(
-                    commonprefix([qualified_name.removesuffix(call_name), public_name])
-                )
-                new_module_name = public_name.removesuffix(new_call_name).removesuffix(
-                    "."
-                )
-                if new_module_name:
-                    self.needed_imports.add(
-                        ImportItem(
-                            module_name=new_module_name,
-                            obj_name=new_call_name.split(".")[0],
-                        )
-                    )
-                replacement = node.with_changes(
-                    func=cst.parse_expression(new_call_name)
-                )
+            replacement_and_imports = new_call_with_name_changes(
+                node, qualified_name, public_name
+            )
+            if replacement_and_imports is not None:
+                replacement, imports = replacement_and_imports
+                self.needed_imports.update(imports)
+            else:
+                replacement = None
 
             self.add_violation(
                 node, error_code=error_code, message=message, replacement=replacement
@@ -83,32 +68,16 @@ class TorchNonPublicAliasVisitor(TorchVisitor):
         if node.module is None:
             return
 
-        module = cst.helpers.get_full_name_for_node(node.module)
-        if not isinstance(node.names, Sequence):
-            return
-
-        for name in node.names:
-            qualified_name = f"{module}.{name.name.value}"
-            if qualified_name in self.ALIASES:
-                public_name = self.ALIASES[qualified_name]
-                error_code = self.ERRORS[1].error_code
-                message = self.ERRORS[1].message(
-                    qualified_name=qualified_name, public_name=public_name
-                )
-
-                new_module = ".".join(public_name.split(".")[:-1])
-                new_name = public_name.split(".")[-1]
-                # Replace only if the import statement has no other names
-                if len(node.names) == 1:
-                    replacement = cst.ImportFrom(
-                        module=cst.parse_expression(new_module),  # type: ignore[arg-type] # noqa: E501
-                        names=[cst.ImportAlias(name=cst.Name(new_name))],
-                    )
-                else:
-                    replacement = None
-                self.add_violation(
-                    node,
-                    error_code=error_code,
-                    message=message,
-                    replacement=replacement,
-                )
+        private_names, replacement = check_old_names_in_import_from(node, self.ALIASES)
+        for qualified_name in private_names:
+            public_name = self.ALIASES[qualified_name]
+            error_code = self.ERRORS[1].error_code
+            message = self.ERRORS[1].message(
+                private_name=qualified_name, public_name=public_name
+            )
+            self.add_violation(
+                node,
+                error_code=error_code,
+                message=message,
+                replacement=replacement,
+            )


### PR DESCRIPTION
This PR refactors code to update calls and imports from `TorchNonPublicAliasVisitor` into common functionality and uses the functionality for `TorchDeprecatedSymbolsVisitor`.

This allowed to fix https://github.com/pytorch-labs/torchfix/issues/50 and resolve a TODO to remove `_UpdateFunctorchImports`.