### PR TITLE
Move development dependencies to `pyproject.toml`

### DIFF
--- a/.github/workflows/test-torchfix.yml
+++ b/.github/workflows/test-torchfix.yml
@@ -10,12 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install requirements
-        run: |
-          pip3 install -r requirements-dev.txt
       - name: Install TorchFix
         run: |
-          pip3 install .
+          pip3 install ".[dev]"
       - name: Run pytest
         run: |
           pytest tests

--- a/.github/workflows/test-torchfix.yml
+++ b/.github/workflows/test-torchfix.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Upgrade build dependencies
+        run: |
+          pip3 install -U pip
+          pip3 install -U setuptools
       - name: Install TorchFix
         run: |
           pip3 install ".[dev]"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,22 +20,22 @@ We actively welcome your pull requests.
 
 ## Linting
 
-We use `black`, `flake8`, and `mypy` to lint the code.
-```
-pip install -r requirements-dev.txt
+We use `black`, `flake8`, and `mypy` to lint the code. Configuration is available to run lints via `pre-commit`.
+
+```shell
+pip install ".[dev]"
 ```
 
 Linting via pre-commit hook:
-```
-# install pre-commit hooks for the first time
-pre-commit install
 
+```shell
 # manually run pre-commit hooks on all files (runs all linters)
 pre-commit run --all-files
 ```
 
 Manually running individual linters:
-```
+
+```shell
 black .
 flake8
 mypy .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "TorchFix"
 requires-python = ">=3.9"
@@ -9,7 +13,22 @@ classifiers = [
   "Programming Language :: Python"
 ]
 dynamic = ["version"]
-dependencies = ["flake8>=3.8.2", "PyYAML", "libcst>=1.1.0,<1.2.0"]
+dependencies = [
+  "flake8>=3.8.2",
+  "PyYAML",
+  "libcst>=1.1.0,<1.2.0"
+]
+
+[project.optional-dependencies]
+dev = [
+  "flake8==6.0.0",
+  "pytest==7.2.0",
+  "libcst==1.1.0",
+  "types-PyYAML==6.0.7",
+  "mypy==1.7.0",
+  "black==24.4.0",
+  "pre-commit==3.7.0",
+]
 
 [project.urls]
 Repository = "https://github.com/pytorch-labs/torchfix"
@@ -30,6 +49,9 @@ pythonpath = [
 
 [tool.black]
 exclude = "tests/fixtures/*"
+
+[tool.setuptools]
+packages = ["torchfix"]
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,6 @@ pythonpath = [
 [tool.black]
 exclude = "tests/fixtures/*"
 
-[tool.setuptools.packages.find]
-include = ["torchfix*"]
-
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools >= 65.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ pythonpath = [
 [tool.black]
 exclude = "tests/fixtures/*"
 
-[tool.setuptools]
-packages = ["torchfix"]
+[tool.setuptools.packages.find]
+include = ["torchfix*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,0 @@
-flake8==6.0.0
-pytest==7.2.0
-libcst==1.1.0
-types-PyYAML==6.0.7
-mypy==1.7.0
-black==24.4.0
-pre-commit==3.7.0


### PR DESCRIPTION
Minor PR to kick-off contributing to `torchfix`. I'm developing new functionality, which I plan to contribute in follow-up PRs. 

Changes:
- Move `requirements-dev.txt` to `optional-dependencies`
- Explicitly set the setuptools build system
- Omit `pip install pre-commit` in CONTRIBUTING.md, already included in dev dependencies