### PR TITLE
Dependabot configuration for maintenance of dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot might need a click or two to [activate](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide), but will help keep the base and dev dependencies up-to-date without much effort.