### PR TITLE
Sort rule codes in CLI

### DIFF
--- a/tests/test_torchfix.py
+++ b/tests/test_torchfix.py
@@ -77,7 +77,7 @@ def test_parse_error_code_str():
         ("TOR102", {"TOR102"}),
         ("TOR102,TOR101", {"TOR102", "TOR101"}),
         ("TOR1,TOR102", {"TOR102", "TOR101", "TOR103", "TOR104", "TOR105"}),
-        (None, GET_ALL_ERROR_CODES() - exclude_set),
+        (None, set(GET_ALL_ERROR_CODES()) - exclude_set),
     ]
     for case, expected in cases:
         assert expected == process_error_code_str(case)

--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -46,7 +46,7 @@ def GET_ALL_ERROR_CODES():
     for cls in ALL_VISITOR_CLS:
         assert issubclass(cls, TorchVisitor)
         codes |= {error.error_code for error in cls.ERRORS}
-    return codes
+    return sorted(codes)
 
 
 @functools.cache
@@ -62,15 +62,12 @@ def expand_error_codes(codes):
 def construct_visitor(cls):
     if cls is TorchDeprecatedSymbolsVisitor:
         return cls(DEPRECATED_CONFIG_PATH)
-    else:
-        return cls()
+
+    return cls()
 
 
 def GET_ALL_VISITORS():
-    out = []
-    for v in ALL_VISITOR_CLS:
-        out.append(construct_visitor(v))
-    return out
+    return [construct_visitor(v) for v in ALL_VISITOR_CLS]
 
 
 def get_visitors_with_error_codes(error_codes):
@@ -87,10 +84,7 @@ def get_visitors_with_error_codes(error_codes):
                 break
         if not found:
             raise AssertionError(f"Unknown error code: {error_code}")
-    out = []
-    for cls in visitor_classes:
-        out.append(construct_visitor(cls))
-    return out
+    return [construct_visitor(cls) for cls in visitor_classes]
 
 
 def process_error_code_str(code_str):
@@ -100,7 +94,7 @@ def process_error_code_str(code_str):
     # Default when --select is not provided.
     if code_str is None:
         exclude_set = expand_error_codes(tuple(DISABLED_BY_DEFAULT))
-        return GET_ALL_ERROR_CODES() - exclude_set
+        return set(GET_ALL_ERROR_CODES()) - exclude_set
 
     raw_codes = [s.strip() for s in code_str.split(",")]
 


### PR DESCRIPTION
Sort the rule codes in the CLI help is more intuitive to the user.

_Before_:
```text
  --select SELECT       Comma-separated list of rules to enable or 'ALL' to enable all rules. Available rules: TOR001, TOR105, TOR402, TOR103, TOR401, TOR201, TOR004, TOR104, TOR501, TOR102,
                        TOR202, TOR403, TOR203, TOR002, TOR901, TOR003, TOR101. Defaults to all except for TOR3, TOR4, TOR9.
```

_After_:
```text
  --select SELECT       Comma-separated list of rules to enable or 'ALL' to enable all rules. Available rules: TOR001, TOR002, TOR003, TOR004, TOR101, TOR102, TOR103, TOR104, TOR105, TOR201,
                        TOR202, TOR203, TOR401, TOR402, TOR403, TOR501, TOR901. Defaults to all except for TOR3, TOR4, TOR9.
```

Changes:

- Sort rule codes
- Minor code modernisation for readability (list comprehension, superfluous else)