### PR TITLE
Refactor: misc best practices

### DIFF
--- a/torchfix/__main__.py
+++ b/torchfix/__main__.py
@@ -40,7 +40,7 @@ def StderrSilencer(redirect: bool = True):
             libc.close(orig_stderr)
 
 
-def main() -> None:
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
@@ -78,11 +78,11 @@ def main() -> None:
         action="store_true",
     )
 
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    if not args.path:
-        parser.print_usage()
-        sys.exit(1)
+
+def main() -> None:
+    args = _parse_args()
 
     files = codemod.gather_files(args.path)
 

--- a/torchfix/__main__.py
+++ b/torchfix/__main__.py
@@ -46,7 +46,7 @@ def main() -> None:
     parser.add_argument(
         "path",
         nargs="+",
-        help=("Path to check/fix. Can be a directory, a file, or multiple of either."),
+        help="Path to check/fix. Can be a directory, a file, or multiple of either.",
     )
     parser.add_argument(
         "--fix",

--- a/torchfix/common.py
+++ b/torchfix/common.py
@@ -26,7 +26,7 @@ class LintViolation:
 
     def flake8_result(self):
         full_message = f"{self.error_code} {self.message}"
-        return (self.line, 1 + self.column, full_message, "TorchFix")
+        return self.line, 1 + self.column, full_message, "TorchFix"
 
     def codemod_result(self) -> str:
         fixable = f" [{CYAN}*{ENDC}]" if self.replacement is not None else ""

--- a/torchfix/common.py
+++ b/torchfix/common.py
@@ -2,7 +2,7 @@ import sys
 from abc import ABC
 from dataclasses import dataclass
 from os.path import commonprefix
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import List, Optional, Sequence, Set, Tuple, Mapping
 
 import libcst as cst
 from libcst.codemod.visitors import ImportItem
@@ -180,7 +180,7 @@ def call_with_name_changes(
 
 
 def check_old_names_in_import_from(
-    node: cst.ImportFrom, old_new_name_map: Dict[str, Optional[str]]
+    node: cst.ImportFrom, old_new_name_map: Mapping[str, Optional[str]]
 ) -> Tuple[List[str], Optional[cst.ImportFrom]]:
     """
     Using `old_new_name_map`, check if there are any old names in the import from.

--- a/torchfix/common.py
+++ b/torchfix/common.py
@@ -56,6 +56,7 @@ class TorchVisitor(cst.BatchableCSTVisitor, ABC):
     ERRORS: List[TorchError]
 
     def __init__(self) -> None:
+        super().__init__()
         self.violations: List[LintViolation] = []
         self.needed_imports: Set[ImportItem] = set()
 
@@ -236,6 +237,7 @@ def check_old_names_in_import_from(
 def deep_multi_replace(tree, replacement_map):
     class MultiChildReplacementTransformer(cst.CSTTransformer):
         def __init__(self, replacement_map) -> None:
+            super().__init__()
             self.replacement_map = replacement_map
 
         def on_leave(self, original_node, updated_node):

--- a/torchfix/common.py
+++ b/torchfix/common.py
@@ -158,7 +158,6 @@ def call_with_name_changes(
         new_call_name = new_qualified_name.removeprefix(
             commonprefix([qualified_name.removesuffix(call_name), new_qualified_name])
         )
-        new_call_name = new_call_name
         new_module_name = new_qualified_name.removesuffix(new_call_name).removesuffix(
             "."
         )

--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -6,19 +6,19 @@ import libcst as cst
 import libcst.codemod as codemod
 
 from .common import deep_multi_replace, TorchVisitor
-from .visitors.deprecated_symbols import TorchDeprecatedSymbolsVisitor
-from .visitors.internal import TorchScopedLibraryVisitor
 
-from .visitors.performance import TorchSynchronizedDataLoaderVisitor
-from .visitors.misc import TorchRequireGradVisitor, TorchReentrantCheckpointVisitor
-from .visitors.nonpublic import TorchNonPublicAliasVisitor
-
-from .visitors.vision import (
+from .visitors import (
+    TorchDeprecatedSymbolsVisitor,
+    TorchNonPublicAliasVisitor,
+    TorchReentrantCheckpointVisitor,
+    TorchRequireGradVisitor,
+    TorchScopedLibraryVisitor,
+    TorchSynchronizedDataLoaderVisitor,
+    TorchUnsafeLoadVisitor,
     TorchVisionDeprecatedPretrainedVisitor,
     TorchVisionDeprecatedToTensorVisitor,
     TorchVisionSingletonImportVisitor,
 )
-from .visitors.security import TorchUnsafeLoadVisitor
 
 __version__ = "0.5.0"
 

--- a/torchfix/visitors/__init__.py
+++ b/torchfix/visitors/__init__.py
@@ -1,0 +1,24 @@
+from .deprecated_symbols import TorchDeprecatedSymbolsVisitor
+from .internal import TorchScopedLibraryVisitor
+from .misc import TorchReentrantCheckpointVisitor, TorchRequireGradVisitor
+from .nonpublic import TorchNonPublicAliasVisitor
+from .performance import TorchSynchronizedDataLoaderVisitor
+from .security import TorchUnsafeLoadVisitor
+from .vision import (
+    TorchVisionDeprecatedPretrainedVisitor,
+    TorchVisionDeprecatedToTensorVisitor,
+    TorchVisionSingletonImportVisitor,
+)
+
+__all__ = [
+    "TorchDeprecatedSymbolsVisitor",
+    "TorchRequireGradVisitor",
+    "TorchScopedLibraryVisitor",
+    "TorchSynchronizedDataLoaderVisitor",
+    "TorchVisionDeprecatedPretrainedVisitor",
+    "TorchVisionDeprecatedToTensorVisitor",
+    "TorchVisionSingletonImportVisitor",
+    "TorchUnsafeLoadVisitor",
+    "TorchReentrantCheckpointVisitor",
+    "TorchNonPublicAliasVisitor",
+]

--- a/torchfix/visitors/deprecated_symbols/__init__.py
+++ b/torchfix/visitors/deprecated_symbols/__init__.py
@@ -36,10 +36,10 @@ class TorchDeprecatedSymbolsVisitor(TorchVisitor):
 
         super().__init__()
         self.deprecated_config = read_deprecated_config(deprecated_config_path)
-        self.old_new_name_map = {}
-        for name in self.deprecated_config:
-            new_name = self.deprecated_config[name].get("replacement")
-            self.old_new_name_map[name] = new_name
+        self.old_new_name_map = {
+            name: self.deprecated_config[name].get("replacement")
+            for name in self.deprecated_config
+        }
 
     def _call_replacement(
         self, node: cst.Call, qualified_name: str

--- a/torchfix/visitors/deprecated_symbols/__init__.py
+++ b/torchfix/visitors/deprecated_symbols/__init__.py
@@ -53,19 +53,19 @@ class TorchDeprecatedSymbolsVisitor(TorchVisitor):
         replacement = None
 
         if qualified_name in replacements_map:
-            replacement = replacements_map[qualified_name](node)
-        else:
-            # Replace names for functions that have drop-in replacement.
-            function_name_replacement = self.deprecated_config.get(
-                qualified_name, {}
-            ).get("replacement", "")
-            if function_name_replacement:
-                replacement_and_imports = call_with_name_changes(
-                    node, qualified_name, function_name_replacement
-                )
-                if replacement_and_imports is not None:
-                    replacement, imports = replacement_and_imports
-                    self.needed_imports.update(imports)
+            return replacements_map[qualified_name](node)
+
+        # Replace names for functions that have drop-in replacement.
+        function_name_replacement = self.deprecated_config.get(qualified_name, {}).get(
+            "replacement", ""
+        )
+        if function_name_replacement:
+            replacement_and_imports = call_with_name_changes(
+                node, qualified_name, function_name_replacement
+            )
+            if replacement_and_imports is not None:
+                replacement, imports = replacement_and_imports
+                self.needed_imports.update(imports)
         return replacement
 
     def visit_ImportFrom(self, node: cst.ImportFrom) -> None:

--- a/torchfix/visitors/deprecated_symbols/chain_matmul.py
+++ b/torchfix/visitors/deprecated_symbols/chain_matmul.py
@@ -7,21 +7,17 @@ def call_replacement_chain_matmul(node: cst.Call) -> cst.CSTNode:
     Replace `torch.chain_matmul` with `torch.linalg.multi_dot`, changing
     multiple parameters to a list.
     """
-    matrices = []
-    out_arg = None
-    for arg in node.args:
-        if arg.keyword is None:
-            matrices.append(cst.Element(value=arg.value))
-        elif arg.keyword.value == "out":
-            out_arg = arg
+    matrices = [
+        cst.Element(value=arg.value) for arg in node.args if arg.keyword is None
+    ]
     matrices_arg = cst.Arg(value=cst.List(elements=matrices))
 
-    if out_arg is None:
-        replacement_args = [matrices_arg]
-    else:
-        replacement_args = [matrices_arg, out_arg]
+    out_arg = None
+    for arg in node.args:
+        if arg.keyword is not None and arg.keyword.value == "out":
+            out_arg = arg
+
+    replacement_args = [matrices_arg] if out_arg is None else [matrices_arg, out_arg]
     module_name = get_module_name(node, "torch")
     replacement = cst.parse_expression(f"{module_name}.linalg.multi_dot(args)")
-    replacement = replacement.with_changes(args=replacement_args)
-
-    return replacement
+    return replacement.with_changes(args=replacement_args)

--- a/torchfix/visitors/deprecated_symbols/cholesky.py
+++ b/torchfix/visitors/deprecated_symbols/cholesky.py
@@ -19,9 +19,14 @@ def call_replacement_cholesky(node: cst.Call) -> cst.CSTNode:
         and cst.ensure_type(upper_arg.value, cst.Name).value == "True"
     ):
         replacement = cst.parse_expression(f"{module_name}.linalg.cholesky(A).mH")
+
+        # Make mypy happy
+        assert isinstance(replacement, (cst.Name, cst.Attribute))
+
+        old_node = cst.ensure_type(replacement.value, cst.Call).args
         replacement = replacement.with_deep_changes(
-            # Ignore type error, see https://github.com/Instagram/LibCST/issues/963
-            old_node=cst.ensure_type(replacement.value, cst.Call).args,  # type: ignore
+            # see https://github.com/Instagram/LibCST/issues/963
+            old_node=old_node,  # type: ignore[arg-type]
             value=[input_arg],
         )
     else:

--- a/torchfix/visitors/deprecated_symbols/qr.py
+++ b/torchfix/visitors/deprecated_symbols/qr.py
@@ -29,6 +29,4 @@ def call_replacement_qr(node: cst.Call) -> Optional[cst.CSTNode]:
         replacement_args = [input_arg]
     module_name = get_module_name(node, "torch")
     replacement = cst.parse_expression(f"{module_name}.linalg.qr(args)")
-    replacement = replacement.with_changes(args=replacement_args)
-
-    return replacement
+    return replacement.with_changes(args=replacement_args)

--- a/torchfix/visitors/deprecated_symbols/range.py
+++ b/torchfix/visitors/deprecated_symbols/range.py
@@ -46,9 +46,10 @@ def call_replacement_range(node: cst.Call) -> Optional[cst.Call]:
             step_arg,
             m.Arg(value=m.UnaryOperation(operator=m.Minus(), expression=m.Integer())),
         ):
-            # Ignore type error here and further in this file.
-            # See https://github.com/Instagram/LibCST/issues/964
-            step = -int(step_arg.value.expression.value)  # type: ignore
+            # make mypy happy
+            assert isinstance(step_arg.value, cst.UnaryOperation)
+            assert isinstance(step_arg.value.expression, cst.Integer)
+            step = -int(step_arg.value.expression.value)
 
         # Bail out, don't know how to update with non-integer `step`.
         else:
@@ -75,10 +76,15 @@ def call_replacement_range(node: cst.Call) -> Optional[cst.Call]:
         end_arg,
         m.Arg(value=m.UnaryOperation(operator=m.Minus(), expression=m.Integer())),
     ):
-        end = -int(end_arg.value.expression.value) + step  # type: ignore
+        op = end_arg.value
+        # make mypy happy
+        assert isinstance(op, cst.UnaryOperation)
+        assert isinstance(op.expression, cst.Integer)
+        end = -int(op.expression.value) + step
         if end < 0:
             updated_end_arg = end_arg.with_deep_changes(
-                old_node=end_arg.value.expression, value=str(-end)  # type: ignore
+                old_node=op.expression,
+                value=str(-end),
             )
         else:
             # `end` became non-negative
@@ -92,7 +98,9 @@ def call_replacement_range(node: cst.Call) -> Optional[cst.Call]:
             value=m.BinaryOperation(operator=m.Subtract(), right=m.Integer(value="1"))
         ),
     ):
-        updated_end_arg = end_arg.with_changes(value=end_arg.value.left)  # type: ignore
+        # make mypy happy
+        assert isinstance(end_arg.value, cst.BinaryOperation)
+        updated_end_arg = end_arg.with_changes(value=end_arg.value.left)
 
     # `end` something else: add `+ 1` at the end
     else:
@@ -104,12 +112,14 @@ def call_replacement_range(node: cst.Call) -> Optional[cst.Call]:
             )
         )
 
-    replacement = node
     if updated_end_arg is not None:
-        # Ignore type error, see https://github.com/Instagram/LibCST/issues/965
-        replacement = replacement.deep_replace(end_arg, updated_end_arg)  # type: ignore
-    replacement = replacement.with_deep_changes(
+        replacement = node.deep_replace(end_arg, updated_end_arg)
+
+        # make mypy happy
+        assert isinstance(replacement, cst.Call)
+    else:
+        replacement = node
+
+    return replacement.with_deep_changes(
         old_node=cst.ensure_type(replacement.func, cst.Attribute).attr, value="arange"
     )
-
-    return replacement

--- a/torchfix/visitors/deprecated_symbols/range.py
+++ b/torchfix/visitors/deprecated_symbols/range.py
@@ -18,11 +18,10 @@ def call_replacement_range(node: cst.Call) -> Optional[cst.Call]:
         for arg in node.args:
             if arg.keyword is None:
                 non_kw_args.append(arg)
-            else:
-                if arg.keyword.value == "end":
-                    end_arg = arg
-                elif arg.keyword.value == "step":
-                    step_arg = arg
+            elif arg.keyword.value == "end":
+                end_arg = arg
+            elif arg.keyword.value == "step":
+                step_arg = arg
         if end_arg is None:
             if len(non_kw_args) == 1:
                 end_arg = non_kw_args[0]

--- a/torchfix/visitors/deprecated_symbols/range.py
+++ b/torchfix/visitors/deprecated_symbols/range.py
@@ -54,8 +54,6 @@ def call_replacement_range(node: cst.Call) -> Optional[cst.Call]:
         else:
             return None
 
-    updated_end_arg = None
-
     # `end` is a literal (positive) integer
     if isinstance(end_arg.value, cst.Integer):
         end = int(end_arg.value.value) + step

--- a/torchfix/visitors/misc/__init__.py
+++ b/torchfix/visitors/misc/__init__.py
@@ -70,7 +70,7 @@ class TorchReentrantCheckpointVisitor(TorchVisitor):
             use_reentrant_arg = cst.ensure_type(
                 cst.parse_expression("f(use_reentrant=False)"), cst.Call
             ).args[0]
-            replacement = node.with_changes(args=node.args + (use_reentrant_arg,))
+            replacement = node.with_changes(args=(*node.args, use_reentrant_arg))
             self.add_violation(
                 node,
                 error_code=self.ERRORS[0].error_code,

--- a/torchfix/visitors/nonpublic/__init__.py
+++ b/torchfix/visitors/nonpublic/__init__.py
@@ -73,7 +73,7 @@ class TorchNonPublicAliasVisitor(TorchVisitor):
         if node.module is None:
             return
 
-        private_names, replacement = check_old_names_in_import_from(node, self.ALIASES)  # type: ignore[arg-type] # noqa: E501
+        private_names, replacement = check_old_names_in_import_from(node, self.ALIASES)
         for qualified_name in private_names:
             public_name = self.ALIASES[qualified_name]
             error_code = self.ERRORS[1].error_code

--- a/torchfix/visitors/security/__init__.py
+++ b/torchfix/visitors/security/__init__.py
@@ -39,7 +39,7 @@ class TorchUnsafeLoadVisitor(TorchVisitor):
                 weights_only_arg = cst.ensure_type(
                     cst.parse_expression("f(weights_only=True)"), cst.Call
                 ).args[0]
-                replacement = node.with_changes(args=node.args + (weights_only_arg,))
+                replacement = node.with_changes(args=(*node.args, weights_only_arg))
             self.add_violation(
                 node,
                 error_code=self.ERRORS[0].error_code,

--- a/torchfix/visitors/vision/__init__.py
+++ b/torchfix/visitors/vision/__init__.py
@@ -1,3 +1,9 @@
-from .pretrained import TorchVisionDeprecatedPretrainedVisitor  # noqa: F401
-from .to_tensor import TorchVisionDeprecatedToTensorVisitor  # noqa: F401
-from .singleton_import import TorchVisionSingletonImportVisitor  # noqa: F401
+from .pretrained import TorchVisionDeprecatedPretrainedVisitor
+from .singleton_import import TorchVisionSingletonImportVisitor
+from .to_tensor import TorchVisionDeprecatedToTensorVisitor
+
+__all__ = [
+    "TorchVisionDeprecatedPretrainedVisitor",
+    "TorchVisionDeprecatedToTensorVisitor",
+    "TorchVisionSingletonImportVisitor",
+]


### PR DESCRIPTION
Split each refactor per commit for easier review:

- Removed unused parentheses
- Added missing super().__init__() calls
- Export visitors for more concise imports
- Removed dead code (unused assignments)
- Instead of suppressing type checking, provided type hints to mypy via `assert` where possible
- Used unpacking instead of concatenation for tuples
- Simplified the control flow where possible (reducing nested blocks etc.)
- `args.path` is already a required argument and validated by argparse, removed `not args.path` which is never reached 

I'll rebase/group the commits and fix test when the other PRs are merged. I've got more functional changes lined up, but will hold off until you've had time to review/merge the outstanding PRs to avoid conflicts.