### PR TITLE
CI: enable testing on macOS

### DIFF
--- a/.github/workflows/test-torchfix.yml
+++ b/.github/workflows/test-torchfix.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10' 
       - name: Upgrade build dependencies
         run: |
           pip3 install -U pip

--- a/.github/workflows/test-torchfix.yml
+++ b/.github/workflows/test-torchfix.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   test-torchfix:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
When I run `torchfix` on macOS the `contextlib.redirect_stderr` works as expected.

However, in the code we make an exception for `Darwin` (macOS):

https://github.com/pytorch-labs/torchfix/blob/main/torchfix/__main__.py#L25

By enabling this test in CI we could test if removal of the dup2 workaround is possible.
