### PR TITLE
Add TorchLog1pVisitor

### DIFF
--- a/tests/fixtures/misc/checker/log1p.py
+++ b/tests/fixtures/misc/checker/log1p.py
@@ -1,0 +1,6 @@
+import torch
+a = torch.randn(5)
+b = torch.log(1 + a)
+c = torch.log(a + 1)
+b = torch.log(1.0 + a)
+c = torch.log(a + 1.0)

--- a/tests/fixtures/misc/checker/log1p.py
+++ b/tests/fixtures/misc/checker/log1p.py
@@ -4,3 +4,6 @@ b = torch.log(1 + a)
 c = torch.log(a + 1)
 b = torch.log(1.0 + a)
 c = torch.log(a + 1.0)
+
+# False negative: can not detect currently
+x = (a + 1).log()

--- a/tests/fixtures/misc/checker/log1p.txt
+++ b/tests/fixtures/misc/checker/log1p.txt
@@ -1,0 +1,4 @@
+3:5 TOR106 Use `torch.log1p(x)` instead of `torch.log(1 + x)`. It is more accurate for small values of `x`.
+4:5 TOR106 Use `torch.log1p(x)` instead of `torch.log(1 + x)`. It is more accurate for small values of `x`.
+5:5 TOR106 Use `torch.log1p(x)` instead of `torch.log(1 + x)`. It is more accurate for small values of `x`.
+6:5 TOR106 Use `torch.log1p(x)` instead of `torch.log(1 + x)`. It is more accurate for small values of `x`.

--- a/tests/test_torchfix.py
+++ b/tests/test_torchfix.py
@@ -35,7 +35,10 @@ def pytest_generate_tests(metafunc):
             ("ALL,TOR102", GET_ALL_ERROR_CODES()),
             ("TOR102", {"TOR102"}),
             ("TOR102,TOR101", {"TOR102", "TOR101"}),
-            ("TOR1,TOR102", {"TOR102", "TOR101", "TOR103", "TOR104", "TOR105"}),
+            (
+                "TOR1,TOR102",
+                {"TOR102", "TOR101", "TOR103", "TOR104", "TOR105", "TOR106"},
+            ),
             (None, set(GET_ALL_ERROR_CODES()) - exclude_set),
         ]
         metafunc.parametrize("case,expected", cases, ids=[case for case, _ in cases])

--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -9,6 +9,7 @@ from .common import deep_multi_replace, TorchVisitor
 
 from .visitors import (
     TorchDeprecatedSymbolsVisitor,
+    TorchLog1pVisitor,
     TorchNonPublicAliasVisitor,
     TorchReentrantCheckpointVisitor,
     TorchRequireGradVisitor,
@@ -28,15 +29,16 @@ DISABLED_BY_DEFAULT = ["TOR3", "TOR4", "TOR9"]
 
 ALL_VISITOR_CLS = [
     TorchDeprecatedSymbolsVisitor,
+    TorchLog1pVisitor,
+    TorchNonPublicAliasVisitor,
     TorchRequireGradVisitor,
+    TorchReentrantCheckpointVisitor,
     TorchScopedLibraryVisitor,
     TorchSynchronizedDataLoaderVisitor,
+    TorchUnsafeLoadVisitor,
     TorchVisionDeprecatedPretrainedVisitor,
     TorchVisionDeprecatedToTensorVisitor,
     TorchVisionSingletonImportVisitor,
-    TorchUnsafeLoadVisitor,
-    TorchReentrantCheckpointVisitor,
-    TorchNonPublicAliasVisitor,
 ]
 
 

--- a/torchfix/visitors/__init__.py
+++ b/torchfix/visitors/__init__.py
@@ -1,6 +1,10 @@
 from .deprecated_symbols import TorchDeprecatedSymbolsVisitor
 from .internal import TorchScopedLibraryVisitor
-from .misc import TorchReentrantCheckpointVisitor, TorchRequireGradVisitor
+from .misc import (
+    TorchReentrantCheckpointVisitor,
+    TorchRequireGradVisitor,
+    TorchLog1pVisitor,
+)
 from .nonpublic import TorchNonPublicAliasVisitor
 from .performance import TorchSynchronizedDataLoaderVisitor
 from .security import TorchUnsafeLoadVisitor
@@ -12,13 +16,14 @@ from .vision import (
 
 __all__ = [
     "TorchDeprecatedSymbolsVisitor",
+    "TorchLog1pVisitor",
+    "TorchNonPublicAliasVisitor",
+    "TorchReentrantCheckpointVisitor",
     "TorchRequireGradVisitor",
     "TorchScopedLibraryVisitor",
     "TorchSynchronizedDataLoaderVisitor",
+    "TorchUnsafeLoadVisitor",
     "TorchVisionDeprecatedPretrainedVisitor",
     "TorchVisionDeprecatedToTensorVisitor",
     "TorchVisionSingletonImportVisitor",
-    "TorchUnsafeLoadVisitor",
-    "TorchReentrantCheckpointVisitor",
-    "TorchNonPublicAliasVisitor",
 ]


### PR DESCRIPTION
Suggest using `torch.log1p(x)` instead of `torch.log(1 + x)`.
Only a checker for now, probably not worth spending time on a codemod as it's not a very common issue.

I used this to create a PR to botorch https://github.com/pytorch/botorch/pull/2539