### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -22,7 +22,7 @@ from .visitors import (
     TorchVisionSingletonImportVisitor,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 DEPRECATED_CONFIG_PATH = "deprecated_symbols.yaml"
 


### PR DESCRIPTION
Preparing 0.6.0 release, which is probably a bit overdue already. Also it's nice to align the release with PyTorch conference.

- Added `torch.utils._pytree._register_pytree_node` and `torch.backends.cuda.sdp_kernel` to the deprecated APIs rules
- Enhanced rule TOR203 to support `torchvision.datasets` and `transforms` in addition to `models`
- Added rules TOR106 and TOR107 to suggest replacing `torch.log(1 + x)` and `torch.exp(x) - 1` with more numerically stable equivalents
- Multiple code refactorings, bug fixes, and quality of life and documentation improvements