### PR TITLE
Update libcst dependency to 1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dynamic = ["version"]
 dependencies = [
   "flake8>=3.8.2",
   "PyYAML",
-  "libcst>=1.1.0,<1.2.0"
+  "libcst>=1.5.0,<1.6.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 dev = [
   "flake8==6.0.0",
   "pytest==7.2.0",
-  "libcst==1.1.0",
+  "libcst==1.5.0",
   "types-PyYAML==6.0.7",
   "mypy==1.7.0",
   "black==24.4.0",


### PR DESCRIPTION
To enable python-3.13 support, see https://github.com/pytorch-labs/torchfix/issues/84