### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/torchfix/torchfix.py
+++ b/torchfix/torchfix.py
@@ -22,7 +22,7 @@ from .visitors import (
     TorchVisionSingletonImportVisitor,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 DEPRECATED_CONFIG_PATH = "deprecated_symbols.yaml"
 


### PR DESCRIPTION
Preparing 0.7.0 release

- Updated libCST dependency to 1.5.0 to support running on Python 3.13
- Added `torch.matrix_rank` and `torch.lstsq` to the list of deprecated/removed APIs