### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ edges and many things can and will change.
 ## Installation
 
 To install the latest code from GitHub, clone/download
-https://github.com/pytorch-labs/torchfix and run `pip install .`
+https://github.com/meta-pytorch/torchfix and run `pip install .`
 inside the directory.
 
 To install a release version from PyPI, run `pip install torchfix`.
@@ -51,7 +51,7 @@ To enable them, use standard flake8 configuration options for the plugin mode or
 ## Reporting problems
 
 If you encounter a bug or some other problem with TorchFix, please file an issue on
-https://github.com/pytorch-labs/torchfix/issues.
+https://github.com/meta-pytorch/torchfix/issues.
 
 ## Rule Code Assignment Policy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dev = [
 ]
 
 [project.urls]
-Repository = "https://github.com/pytorch-labs/torchfix"
-"Bug Tracker" = "https://github.com/pytorch-labs/torchfix/issues"
+Repository = "https://github.com/meta-pytorch/torchfix"
+"Bug Tracker" = "https://github.com/meta-pytorch/torchfix/issues"
 
 [project.scripts]
 torchfix = "torchfix.__main__:main"

--- a/tests/fixtures/deprecated_symbols/checker/removed_solve.txt
+++ b/tests/fixtures/deprecated_symbols/checker/removed_solve.txt
@@ -1,1 +1,1 @@
-4:1 TOR001 Use of removed function torch.solve: https://github.com/pytorch-labs/torchfix#torchsolve
+4:1 TOR001 Use of removed function torch.solve: https://github.com/meta-pytorch/torchfix#torchsolve

--- a/tests/fixtures/deprecated_symbols/checker/sdp_kernel.txt
+++ b/tests/fixtures/deprecated_symbols/checker/sdp_kernel.txt
@@ -1,4 +1,4 @@
-3:1 TOR103 Import of deprecated function torch.backends.cuda.sdp_kernel: https://github.com/pytorch-labs/torchfix#torchbackendscudasdp_kernel
-5:6 TOR101 Use of deprecated function torch.backends.cuda.sdp_kernel: https://github.com/pytorch-labs/torchfix#torchbackendscudasdp_kernel
-8:6 TOR101 Use of deprecated function torch.backends.cuda.sdp_kernel: https://github.com/pytorch-labs/torchfix#torchbackendscudasdp_kernel
-11:6 TOR101 Use of deprecated function torch.backends.cuda.sdp_kernel: https://github.com/pytorch-labs/torchfix#torchbackendscudasdp_kernel
+3:1 TOR103 Import of deprecated function torch.backends.cuda.sdp_kernel: https://github.com/meta-pytorch/torchfix#torchbackendscudasdp_kernel
+5:6 TOR101 Use of deprecated function torch.backends.cuda.sdp_kernel: https://github.com/meta-pytorch/torchfix#torchbackendscudasdp_kernel
+8:6 TOR101 Use of deprecated function torch.backends.cuda.sdp_kernel: https://github.com/meta-pytorch/torchfix#torchbackendscudasdp_kernel
+11:6 TOR101 Use of deprecated function torch.backends.cuda.sdp_kernel: https://github.com/meta-pytorch/torchfix#torchbackendscudasdp_kernel

--- a/tests/fixtures/deprecated_symbols/checker/weight_norm.txt
+++ b/tests/fixtures/deprecated_symbols/checker/weight_norm.txt
@@ -1,1 +1,1 @@
-2:5 TOR101 Use of deprecated function torch.nn.utils.weight_norm: https://github.com/pytorch-labs/torchfix#torchnnutilsweight_norm
+2:5 TOR101 Use of deprecated function torch.nn.utils.weight_norm: https://github.com/meta-pytorch/torchfix#torchnnutilsweight_norm

--- a/torchfix/deprecated_symbols.yaml
+++ b/torchfix/deprecated_symbols.yaml
@@ -1,7 +1,7 @@
 - name: torch.solve
   deprecate_pr: https://github.com/pytorch/pytorch/pull/57741
   remove_pr: https://github.com/pytorch/pytorch/pull/70986
-  reference: https://github.com/pytorch-labs/torchfix#torchsolve
+  reference: https://github.com/meta-pytorch/torchfix#torchsolve
 
 - name: torch.qr
   deprecate_pr: https://github.com/pytorch/pytorch/pull/57745
@@ -71,7 +71,7 @@
 - name: torch.nn.utils.weight_norm
   deprecate_pr: https://github.com/pytorch/pytorch/pull/103001
   remove_pr:
-  reference: https://github.com/pytorch-labs/torchfix#torchnnutilsweight_norm
+  reference: https://github.com/meta-pytorch/torchfix#torchnnutilsweight_norm
 
 - name: torch.utils._pytree._register_pytree_node
   deprecate_pr: https://github.com/pytorch/pytorch/pull/112111
@@ -81,7 +81,7 @@
 - name: torch.backends.cuda.sdp_kernel
   deprecate_pr: https://github.com/pytorch/pytorch/pull/114689
   remove_pr:
-  reference: https://github.com/pytorch-labs/torchfix#torchbackendscudasdp_kernel
+  reference: https://github.com/meta-pytorch/torchfix#torchbackendscudasdp_kernel
 
 - name: torch.cuda.amp.autocast
   deprecate_pr: TBA


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:26:44.714975+00:00Z